### PR TITLE
Default GpioButton to active high

### DIFF
--- a/libnymea-gpio/gpiobutton.h
+++ b/libnymea-gpio/gpiobutton.h
@@ -59,7 +59,7 @@ public:
 
 private:
     int m_gpioNumber;
-    bool m_activeLow = true;
+    bool m_activeLow = false;
     bool m_repeateLongPressed = false;
     int m_longPressedTimeout = 250;
     QString m_name;


### PR DESCRIPTION
This is the more common default, and also used to be the default in here, but only changed after fixing
active high/low being swapped in https://github.com/nymea/nymea-gpio/pull/7